### PR TITLE
Fix assembly versions not being included in plugin .dlls

### DIFF
--- a/cccore/cccore.csproj
+++ b/cccore/cccore.csproj
@@ -16,8 +16,6 @@
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/cccore/cccore.csproj
+++ b/cccore/cccore.csproj
@@ -14,8 +14,6 @@
     <Description>Creditcoin core</Description>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/cccore/cccore.csproj
+++ b/cccore/cccore.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <ApplicationIcon />
-    <StartupObject />
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    
     <AssemblyName>cccore</AssemblyName>
     <RootNamespace>cccore</RootNamespace>
     <PackageId>cccore</PackageId>
@@ -15,8 +12,12 @@
     <Authors>Gluwa</Authors>
     <Company>Gluwa</Company>
     <Description>Creditcoin core</Description>
-    <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.1.0</Version>
+    <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/ccplugin/ccplugin.csproj
+++ b/ccplugin/ccplugin.csproj
@@ -14,8 +14,6 @@
     <Description>Creditcoin plugin</Description>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/ccplugin/ccplugin.csproj
+++ b/ccplugin/ccplugin.csproj
@@ -16,8 +16,6 @@
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/ccplugin/ccplugin.csproj
+++ b/ccplugin/ccplugin.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AssemblyName>ccplugin</AssemblyName>
     <RootNamespace>ccplugin</RootNamespace>
     <PackageId>ccplugin</PackageId>
@@ -12,6 +14,10 @@
     <Description>Creditcoin plugin</Description>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/plugins/bitcoin/cbitcoin.csproj
+++ b/plugins/bitcoin/cbitcoin.csproj
@@ -15,8 +15,6 @@
     <Description>Creditcoin plugin for bitcoin transactions</Description>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/plugins/bitcoin/cbitcoin.csproj
+++ b/plugins/bitcoin/cbitcoin.csproj
@@ -17,8 +17,6 @@
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/plugins/bitcoin/cbitcoin.csproj
+++ b/plugins/bitcoin/cbitcoin.csproj
@@ -1,10 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputPath>..\bin\$(Configuration)</OutputPath>
+    <AssemblyName>cbitcoin</AssemblyName>
+    <RootNamespace>cbitcoin</RootNamespace>
+    <PackageId>cbitcoin</PackageId>
+    <PackageTags>Gluwa</PackageTags>
+    <Authors>Gluwa</Authors>
+    <Company>Gluwa</Company>
+    <Description>Creditcoin plugin for bitcoin transactions</Description>
+    <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
+    <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/plugins/erc20/cerc20.csproj
+++ b/plugins/erc20/cerc20.csproj
@@ -15,8 +15,6 @@
     <Description>Creditcoin plugin for erc20 transactions</Description>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/plugins/erc20/cerc20.csproj
+++ b/plugins/erc20/cerc20.csproj
@@ -1,19 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputPath>..\bin\$(Configuration)</OutputPath>
+    <AssemblyName>cerc20</AssemblyName>
+    <RootNamespace>cerc20</RootNamespace>
+    <PackageId>cerc20</PackageId>
+    <PackageTags>Gluwa</PackageTags>
+    <Authors>Gluwa</Authors>
+    <Company>Gluwa</Company>
+    <Description>Creditcoin plugin for erc20 transactions</Description>
+    <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
+    <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
     <PackageReference Include="Google.Protobuf" Version="3.15.8" />
+    <PackageReference Include="Nethereum.ABI" Version="3.8.0" />
     <PackageReference Include="Nethereum.Contracts" Version="3.8.0" />
     <PackageReference Include="Nethereum.Hex" Version="3.8.0" />
     <PackageReference Include="Nethereum.JsonRpc.Client" Version="3.8.0" />

--- a/plugins/erc20/cerc20.csproj
+++ b/plugins/erc20/cerc20.csproj
@@ -17,8 +17,6 @@
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/plugins/ethereum/cethereum.csproj
+++ b/plugins/ethereum/cethereum.csproj
@@ -1,10 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputPath>..\bin\$(Configuration)</OutputPath>
+    <AssemblyName>cethereum</AssemblyName>
+    <RootNamespace>cethereum</RootNamespace>
+    <PackageId>cethereum</PackageId>
+    <PackageTags>Gluwa</PackageTags>
+    <Authors>Gluwa</Authors>
+    <Company>Gluwa</Company>
+    <Description>Creditcoin plugin for ethereum transactions</Description>
+    <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
+    <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -14,6 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
     <PackageReference Include="Google.Protobuf" Version="3.15.8" />
+    <PackageReference Include="Nethereum.ABI" Version="3.8.0" />
     <PackageReference Include="Nethereum.Contracts" Version="3.8.0" />
     <PackageReference Include="Nethereum.Hex" Version="3.8.0" />
     <PackageReference Include="Nethereum.JsonRpc.Client" Version="3.8.0" />

--- a/plugins/ethereum/cethereum.csproj
+++ b/plugins/ethereum/cethereum.csproj
@@ -15,8 +15,6 @@
     <Description>Creditcoin plugin for ethereum transactions</Description>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/plugins/ethereum/cethereum.csproj
+++ b/plugins/ethereum/cethereum.csproj
@@ -17,8 +17,6 @@
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/plugins/ethless/cethless.csproj
+++ b/plugins/ethless/cethless.csproj
@@ -1,10 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputPath>..\bin\$(Configuration)</OutputPath>
+    <AssemblyName>cethless</AssemblyName>
+    <RootNamespace>cethless</RootNamespace>
+    <PackageId>cethless</PackageId>
+    <PackageTags>Gluwa</PackageTags>
+    <Authors>Gluwa</Authors>
+    <Company>Gluwa</Company>
+    <Description>Creditcoin plugin for ethless transactions</Description>
+    <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
+    <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/plugins/ethless/cethless.csproj
+++ b/plugins/ethless/cethless.csproj
@@ -15,8 +15,6 @@
     <Description>Creditcoin plugin for ethless transactions</Description>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
-    <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/plugins/ethless/cethless.csproj
+++ b/plugins/ethless/cethless.csproj
@@ -17,8 +17,6 @@
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</AssemblyVersion>
     <AssemblyVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</AssemblyVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</FileVersion>
-    <FileVersion Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</FileVersion>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <RuntimeIdentifiers>win-x64;ubuntu-x64</RuntimeIdentifiers>
   </PropertyGroup>


### PR DESCRIPTION
Versions are set at build-time:
- File version: Major.Minor.Patch.Revision (e.g. 1.0.28.0)
- Product version : Major.Minor.Patch[-preview] (e.g. 1.0.28-preview on dev, or 1.0.28 on main)

If the variable BUILD_BUILDNUMBER is not set in the build environment, 1.0.0.0 is used.