### PR TITLE
Updating tx version

### DIFF
--- a/ccplugin/TxBuilder.cs
+++ b/ccplugin/TxBuilder.cs
@@ -34,7 +34,7 @@ namespace ccplugin
     {
         private readonly Signer mSigner;
         private const string CREDITCOIN = "CREDITCOIN";
-        private const string version = "1.6";
+        private const string version = "2.0";
         private const string pluginsFolderName = "plugins";
         private static string prefix = CREDITCOIN.ToByteArray().ToSha512().ToHexString().Substring(0, 6);
         private const int SKIP_TO_GET_60 = 512 / 8 * 2 - 60; // 512 - hash size, 8 - bits in byte, 2 - hex digits for byte, 60 - merkle address length (70) without namespace length (6) and prexix length (4)


### PR DESCRIPTION
To fix block verification in sawtooth 1.2 - the following PRs are all related and should be reviewed and merged together:
CRB-236/sdk-accepts-block-num-for-list-by-prefix
CRB-236/validator-fixes-block-verification
CRB-236/tp-fixes-block-verification
CRB-236/core-updating-tx-version
